### PR TITLE
Add example config and remove const.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+const.js

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Iceland Travel Site
+
+This project displays an Iceland travel itinerary that relies on a Google Maps API key. The deployed site provides the key through GitHub Actions.
+
+## Local Development
+
+1. Copy `const.example.js` to `const.js` in the project root:
+   
+   ```bash
+   cp const.example.js const.js
+   ```
+
+2. Replace `__REPLACE_ME__` with your own Google Maps API key inside `const.js`.
+
+The file `const.js` is ignored by Git and should not be committed.
+
+## CI Workflow
+
+The GitHub Actions workflow generates `const.js` automatically using the secret `GOOGLE_MAPS_API_KEY` during deployment.

--- a/const.example.js
+++ b/const.example.js
@@ -1,0 +1,1 @@
+export const GOOGLE_MAPS_API_KEY = "__REPLACE_ME__";

--- a/const.js
+++ b/const.js
@@ -1,1 +1,0 @@
-export const GOOGLE_MAPS_API_KEY = "AIzaSyCdt452iW7fc_Zqxz0oJbuKKbydK2KAkSs";


### PR DESCRIPTION
## Summary
- remove the real `const.js`
- ignore `const.js` in git
- add `const.example.js` with a placeholder API key
- document how to copy the example file locally and note CI generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684045e9d5308333b9a6a28603944ff5