### PR TITLE
Fix quoting in env injection step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Inject .env for build
         run: |
-          echo "VITE_GOOGLE_MAPS_API_KEY= \"${{ secrets.GOOGLE_MAPS_API_KEY }}\" > .env
+          echo "VITE_GOOGLE_MAPS_API_KEY=\"${{ secrets.GOOGLE_MAPS_API_KEY }}\"" > .env
 
       - name: Build Vite site
         run: npm run build


### PR DESCRIPTION
## Summary
- fix quoting error in the GitHub Actions deploy workflow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c313e708483339a263fb17ea6e1ca